### PR TITLE
Made step size a parameter of NewTOTP

### DIFF
--- a/totp_test.go
+++ b/totp_test.go
@@ -9,10 +9,11 @@ import (
 	"crypto/sha512"
 	"encoding/base64"
 	"encoding/hex"
-	"github.com/sec51/convert/bigendian"
 	"net/url"
 	"testing"
 	"time"
+
+	"github.com/sec51/convert/bigendian"
 )
 
 var sha1KeyHex = "3132333435363738393031323334353637383930"
@@ -121,7 +122,7 @@ func TestTOTP(t *testing.T) {
 
 func TestVerificationFailures(t *testing.T) {
 
-	otp, err := NewTOTP("info@sec51.com", "Sec51", crypto.SHA1, 7)
+	otp, err := NewTOTP("info@sec51.com", "Sec51", crypto.SHA1, 7, 30)
 	//checkError(t, err)
 	if err != nil {
 		t.Fatal(err)
@@ -223,7 +224,7 @@ func TestIncrementCounter(t *testing.T) {
 
 func TestSerialization(t *testing.T) {
 	// create a new TOTP
-	otp, err := NewTOTP("info@sec51.com", "Sec51", crypto.SHA512, 8)
+	otp, err := NewTOTP("info@sec51.com", "Sec51", crypto.SHA512, 8, 30)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -346,10 +347,23 @@ func TestProperInitialization(t *testing.T) {
 	}
 }
 
+func TestNewTOTP(t *testing.T) {
+	otp, err := NewTOTP("info@sec51.com", "Sec51", crypto.SHA512, 10, 0)
+	if err != nil {
+		t.Fatal("NewTOTP returned error")
+	}
+	if otp.digits != 8 {
+		t.Error("digits did not default to 8")
+	}
+	if otp.stepSize != 30 {
+		t.Error("Step size did not default to 30 seconds")
+	}
+}
+
 func TestCounterSynchronization(t *testing.T) {
 
 	// create totp
-	otp, err := NewTOTP("info@sec51.com", "Sec51", crypto.SHA512, 8)
+	otp, err := NewTOTP("info@sec51.com", "Sec51", crypto.SHA512, 8, 30)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
During end-to-end testing it is sometimes necessary to increase (or decrease) the step size value to allow external scripts or busy humans to react.
Also some users might require a longer period of time, particularly those with accessibility issues.
This PR adds a step parameter into NewTOTP, which will default to 30 seconds if not sensible (test case included).
This is an API breaking change.