### PR TITLE
Make Totp.url() public

### DIFF
--- a/totp.go
+++ b/totp.go
@@ -281,7 +281,7 @@ func (otp *Totp) Secret() string {
 
 // URL returns a suitable URL, such as for the Google Authenticator app
 // example: otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Example
-func (otp *Totp) url() (string, error) {
+func (otp *Totp) Url() (string, error) {
 
 	// verify the proper initialization
 	if err := totpHasBeenInitialized(otp); err != nil {
@@ -322,7 +322,7 @@ func (otp *Totp) url() (string, error) {
 func (otp *Totp) QR() ([]byte, error) {
 
 	// get the URL
-	u, err := otp.url()
+	u, err := otp.Url()
 
 	// check for errors during initialization
 	// this is already done on the URL method

--- a/totp_test.go
+++ b/totp_test.go
@@ -308,12 +308,12 @@ func TestSerialization(t *testing.T) {
 		t.Error("Deserialized hash property differ from original TOTP")
 	}
 
-	deserializedUrl, err := deserializedOTP.url()
+	deserializedUrl, err := deserializedOTP.Url()
 	if err != nil {
 		t.Error(err)
 	}
 
-	otpdUrl, err := otp.url()
+	otpdUrl, err := otp.Url()
 	if err != nil {
 		t.Error(err)
 	}
@@ -342,7 +342,7 @@ func TestSerialization(t *testing.T) {
 
 func TestProperInitialization(t *testing.T) {
 	otp := Totp{}
-	if _, err := otp.url(); err == nil {
+	if _, err := otp.Url(); err == nil {
 		t.Fatal("Totp is not properly initialized and the method did not catch it")
 	}
 }


### PR DESCRIPTION
So that it can be used by code that needs to expose the URL through means other than the PNG image returned by Totp.QR().